### PR TITLE
fix: scripts on custom chains

### DIFF
--- a/ignition/modules/main.ts
+++ b/ignition/modules/main.ts
@@ -18,38 +18,4 @@ const MetaDogModule = buildModule('MetaDogModule', (m) => {
   return { metadog };
 });
 
-const MetaDogReserve = buildModule('MetaDogReserve', (m) => {
-  const metadogAddress = m.getParameter('address');
-  const metadog = m.contractAt('MetaDog', metadogAddress);
-  m.call(metadog, 'collectReserves');
-
-  return { metadog };
-});
-
-const MetaDogPresale = buildModule('MetaDogPresale', (m) => {
-  const metadogAddress = m.getParameter('address');
-  const whitelistRoot = m.getParameter('whitelistRoot');
-  const metadog = m.contractAt('MetaDog', metadogAddress);
-  m.call(metadog, 'setWhitelistMerkleRoot', [whitelistRoot]);
-  return { metadog };
-});
-
-const MetaDogPublicSale = buildModule('MetaDogPublicSale', (m) => {
-  const metadogAddress = m.getParameter('address');
-  const metadog = m.contractAt('MetaDog', metadogAddress);
-  m.call(metadog, 'startPublicSale');
-
-  return { metadog };
-});
-
-const MetaDogReveal = buildModule('MetaDogReveal', (m) => {
-  const metadogAddress = m.getParameter('address');
-  const revealTokenURI = m.getParameter('revealTokenURI');
-  const metadog = m.contractAt('MetaDog', metadogAddress);
-
-  m.call(metadog, 'setBaseURI', [`ipfs://${revealTokenURI}/`]);
-  return { metadog };
-});
-
 export default MetaDogModule;
-export { MetaDogReserve, MetaDogPresale, MetaDogPublicSale, MetaDogReveal };

--- a/ignition/modules/metaDogPresale.ts
+++ b/ignition/modules/metaDogPresale.ts
@@ -1,0 +1,11 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+const MetaDogPresale = buildModule('MetaDogPresale', (m) => {
+  const metadogAddress = m.getParameter('address');
+  const whitelistRoot = m.getParameter('whitelistRoot');
+  const metadog = m.contractAt('MetaDog', metadogAddress);
+  m.call(metadog, 'setWhitelistMerkleRoot', [whitelistRoot]);
+  return { metadog };
+});
+
+export default MetaDogPresale;

--- a/ignition/modules/metaDogPublicSale.ts
+++ b/ignition/modules/metaDogPublicSale.ts
@@ -1,0 +1,11 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+const MetaDogPublicSale = buildModule('MetaDogPublicSale', (m) => {
+  const metadogAddress = m.getParameter('address');
+  const metadog = m.contractAt('MetaDog', metadogAddress);
+  m.call(metadog, 'startPublicSale');
+
+  return { metadog };
+});
+
+export default MetaDogPublicSale;

--- a/ignition/modules/metaDogReserve.ts
+++ b/ignition/modules/metaDogReserve.ts
@@ -1,0 +1,11 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+const MetaDogReserve = buildModule('MetaDogReserve', (m) => {
+  const metadogAddress = m.getParameter('address');
+  const metadog = m.contractAt('MetaDog', metadogAddress);
+  m.call(metadog, 'collectReserves');
+
+  return { metadog };
+});
+
+export default MetaDogReserve;

--- a/ignition/modules/metaDogReveal.ts
+++ b/ignition/modules/metaDogReveal.ts
@@ -1,0 +1,12 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+const MetaDogReveal = buildModule('MetaDogReveal', (m) => {
+  const metadogAddress = m.getParameter('address');
+  const revealTokenURI = m.getParameter('revealTokenURI');
+  const metadog = m.contractAt('MetaDog', metadogAddress);
+
+  m.call(metadog, 'setBaseURI', [`ipfs://${revealTokenURI}/`]);
+  return { metadog };
+});
+
+export default MetaDogReveal;

--- a/scripts/collectReserved.ts
+++ b/scripts/collectReserved.ts
@@ -1,31 +1,75 @@
-import { readFileSync } from 'fs';
-import hre, { network } from 'hardhat';
-import { MetaDogReserve } from '../ignition/modules/main';
+import { execSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { network, run } from 'hardhat';
+import path from 'path';
 
 async function main() {
+  // Check if the image collection exists
   const collectionExists = await run('check-images');
-
   if (!collectionExists) {
     throw new Error('You have not created any assets.');
   }
+
+  // Get the chain ID
   const chainIdHex = await network.provider.send('eth_chainId');
   const chainId = String(parseInt(chainIdHex, 16));
 
+  // Read the deployed addresses JSON to get the MetaDog contract address
+  const deployedAddressesPath = `./ignition/deployments/chain-${chainId}/deployed_addresses.json`;
+  let address: string;
   try {
-    const jsonData = JSON.parse(
-      readFileSync(
-        `./ignition/deployments/chain-${chainId}/deployed_addresses.json`,
-        'utf8'
-      )
-    );
-    const address = jsonData['MetaDogModule#MetaDog'];
-    const { metadog } = await hre.ignition.deploy(MetaDogReserve, {
-      parameters: {
-        MetaDogReserve: { address: address },
-      },
-    });
+    const jsonData = JSON.parse(readFileSync(deployedAddressesPath, 'utf8'));
+    address = jsonData['MetaDogModule#MetaDog'];
+    if (!address) {
+      throw new Error(
+        `MetaDogModule address not found in ${deployedAddressesPath}`
+      );
+    }
   } catch (err) {
-    console.error('Error:', err);
+    console.error('Error reading deployed addresses:', err);
+    throw err;
+  }
+
+  console.log(`MetaDog contract address: ${address}`);
+
+  // Prepare the parameters
+  const parameters = {
+    MetaDogReserve: {
+      address,
+    },
+  };
+
+  // Define the parameter file path
+  const dirPath = path.resolve(__dirname, '../ignition/parameters');
+  const filePath = path.resolve(dirPath, 'metaDogReserve.json');
+
+  // Ensure the parameters directory exists
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+    console.log(`Directory created: ${dirPath}`);
+  }
+
+  // Write the parameters to the file
+  writeFileSync(filePath, JSON.stringify(parameters, null, 2));
+  console.log(`Parameters written to ${filePath}:`);
+  console.log(JSON.stringify(parameters, null, 2));
+
+  // Construct the deployment command
+  const modulePath = path.resolve(
+    __dirname,
+    '../ignition/modules/metaDogReserve.ts'
+  );
+  const command = `npx hardhat ignition deploy ${modulePath} --parameters ${filePath} --network btp`;
+
+  console.log(`Executing deployment: ${command}`);
+
+  // Execute the deployment command
+  try {
+    execSync(command, { stdio: 'inherit' });
+    console.log('MetaDogReserve deployed successfully.');
+  } catch (err) {
+    console.error('Error during deployment:', err);
+    throw err;
   }
 }
 

--- a/scripts/presale.ts
+++ b/scripts/presale.ts
@@ -1,36 +1,88 @@
-import { readFileSync } from 'fs';
-import hre, { network } from 'hardhat';
-import { MetaDogPresale } from '../ignition/modules/main';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import hre, { network, run } from 'hardhat';
+import path from 'path';
+import { execSync } from 'child_process';
 
 async function main() {
+  // Check if the image collection exists
   const collectionExists = await run('check-images');
-
   if (!collectionExists) {
     throw new Error('You have not created any assets.');
   }
+
+  // Get the chain ID
   const chainIdHex = await network.provider.send('eth_chainId');
   const chainId = String(parseInt(chainIdHex, 16));
 
-  const whitelist: {
-    root: string;
-    proofs: string[];
-  } = JSON.parse(readFileSync('./assets/generated/whitelist.json', 'utf8'));
-
+  // Read the whitelist JSON file
+  let whitelist: { root: string; proofs: string[] };
   try {
-    const jsonData = JSON.parse(
-      readFileSync(
-        `./ignition/deployments/chain-${chainId}/deployed_addresses.json`,
-        'utf8'
-      )
+    whitelist = JSON.parse(
+      readFileSync('./assets/generated/whitelist.json', 'utf8')
     );
-    const address = jsonData['MetaDogModule#MetaDog'];
-    const { metadog } = await hre.ignition.deploy(MetaDogPresale, {
-      parameters: {
-        MetaDogPresale: { address: address, whitelistRoot: whitelist.root },
-      },
-    });
   } catch (err) {
-    console.error('Error:', err);
+    console.error('Error reading whitelist file:', err);
+    throw err;
+  }
+  console.log(`Whitelist root: ${whitelist.root}`);
+
+  // Read the deployed addresses JSON to get the MetaDog contract address
+  const deployedAddressesPath = `./ignition/deployments/chain-${chainId}/deployed_addresses.json`;
+  let address: string;
+  try {
+    const jsonData = JSON.parse(readFileSync(deployedAddressesPath, 'utf8'));
+    address = jsonData['MetaDogModule#MetaDog'];
+    if (!address) {
+      throw new Error(
+        `MetaDogModule address not found in ${deployedAddressesPath}`
+      );
+    }
+  } catch (err) {
+    console.error('Error reading deployed addresses:', err);
+    throw err;
+  }
+
+  console.log(`MetaDog contract address: ${address}`);
+
+  // Prepare the parameters
+  const parameters = {
+    MetaDogPresale: {
+      address,
+      whitelistRoot: whitelist.root,
+    },
+  };
+
+  // Define the parameter file path
+  const dirPath = path.resolve(__dirname, '../ignition/parameters');
+  const filePath = path.resolve(dirPath, 'metadogPresale.json');
+
+  // Ensure the parameters directory exists
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+    console.log(`Directory created: ${dirPath}`);
+  }
+
+  // Write the parameters to the file
+  writeFileSync(filePath, JSON.stringify(parameters, null, 2));
+  console.log(`Parameters written to ${filePath}:`);
+  console.log(JSON.stringify(parameters, null, 2));
+
+  // Construct the deployment command
+  const modulePath = path.resolve(
+    __dirname,
+    '../ignition/modules/metaDogPresale.ts'
+  );
+  const command = `npx hardhat ignition deploy ${modulePath} --parameters ${filePath} --network btp`;
+
+  console.log(`Executing deployment: ${command}`);
+
+  // Execute the deployment command
+  try {
+    execSync(command, { stdio: 'inherit' });
+    console.log('MetaDogPresale deployed successfully.');
+  } catch (err) {
+    console.error('Error during deployment:', err);
+    throw err;
   }
 }
 

--- a/scripts/publicSale.ts
+++ b/scripts/publicSale.ts
@@ -1,31 +1,75 @@
-import { readFileSync } from 'fs';
-import hre, { network } from 'hardhat';
-import { MetaDogPublicSale } from '../ignition/modules/main';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import hre, { network, run } from 'hardhat';
+import path from 'path';
+import { execSync } from 'child_process';
 
 async function main() {
+  // Check if the image collection exists
   const collectionExists = await run('check-images');
-
   if (!collectionExists) {
     throw new Error('You have not created any assets.');
   }
+
+  // Get the chain ID
   const chainIdHex = await network.provider.send('eth_chainId');
   const chainId = String(parseInt(chainIdHex, 16));
 
+  // Read the deployed addresses JSON to get the MetaDog contract address
+  const deployedAddressesPath = `./ignition/deployments/chain-${chainId}/deployed_addresses.json`;
+  let address: string;
   try {
-    const jsonData = JSON.parse(
-      readFileSync(
-        `./ignition/deployments/chain-${chainId}/deployed_addresses.json`,
-        'utf8'
-      )
-    );
-    const address = jsonData['MetaDogModule#MetaDog'];
-    const { metadog } = await hre.ignition.deploy(MetaDogPublicSale, {
-      parameters: {
-        MetaDogPublicSale: { address: address },
-      },
-    });
+    const jsonData = JSON.parse(readFileSync(deployedAddressesPath, 'utf8'));
+    address = jsonData['MetaDogModule#MetaDog'];
+    if (!address) {
+      throw new Error(
+        `MetaDogModule address not found in ${deployedAddressesPath}`
+      );
+    }
   } catch (err) {
-    console.error('Error:', err);
+    console.error('Error reading deployed addresses:', err);
+    throw err;
+  }
+
+  console.log(`MetaDog contract address: ${address}`);
+
+  // Prepare the parameters
+  const parameters = {
+    MetaDogPublicSale: {
+      address,
+    },
+  };
+
+  // Define the parameter file path
+  const dirPath = path.resolve(__dirname, '../ignition/parameters');
+  const filePath = path.resolve(dirPath, 'metaDogPublicSale.json');
+
+  // Ensure the parameters directory exists
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+    console.log(`Directory created: ${dirPath}`);
+  }
+
+  // Write the parameters to the file
+  writeFileSync(filePath, JSON.stringify(parameters, null, 2));
+  console.log(`Parameters written to ${filePath}:`);
+  console.log(JSON.stringify(parameters, null, 2));
+
+  // Construct the deployment command
+  const modulePath = path.resolve(
+    __dirname,
+    '../ignition/modules/metaDogPublicSale.ts'
+  );
+  const command = `npx hardhat ignition deploy ${modulePath} --parameters ${filePath} --network btp`;
+
+  console.log(`Executing deployment: ${command}`);
+
+  // Execute the deployment command
+  try {
+    execSync(command, { stdio: 'inherit' });
+    console.log('MetaDogPublicSale deployed successfully.');
+  } catch (err) {
+    console.error('Error during deployment:', err);
+    throw err;
   }
 }
 

--- a/scripts/reveal.ts
+++ b/scripts/reveal.ts
@@ -1,31 +1,83 @@
-import { readFileSync } from 'fs';
-import hre, { network } from 'hardhat';
-import { MetaDogReveal } from '../ignition/modules/main';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import hre, { network, run } from 'hardhat';
+import path from 'path';
+import { execSync } from 'child_process';
 
 async function main() {
+  // Check if the image collection exists
   const collectionExists = await run('check-images');
-
   if (!collectionExists) {
     throw new Error('You have not created any assets.');
   }
+
+  // Get the chain ID
   const chainIdHex = await network.provider.send('eth_chainId');
   const chainId = String(parseInt(chainIdHex, 16));
+
+  // Get the reveal token URI
   const revealTokenURI = await run('reveal');
+  if (!revealTokenURI) {
+    throw new Error('Reveal token URI could not be generated.');
+  }
+  console.log(`Reveal Token URI: ${revealTokenURI}`);
+
+  // Read the deployed addresses JSON to get the MetaDog contract address
+  const deployedAddressesPath = `./ignition/deployments/chain-${chainId}/deployed_addresses.json`;
+  let address: string;
   try {
-    const jsonData = JSON.parse(
-      readFileSync(
-        `./ignition/deployments/chain-${chainId}/deployed_addresses.json`,
-        'utf8'
-      )
-    );
-    const address = jsonData['MetaDogModule#MetaDog'];
-    const { metadog } = await hre.ignition.deploy(MetaDogReveal, {
-      parameters: {
-        MetaDogReveal: { address: address, revealTokenURI: revealTokenURI },
-      },
-    });
+    const jsonData = JSON.parse(readFileSync(deployedAddressesPath, 'utf8'));
+    address = jsonData['MetaDogModule#MetaDog'];
+    if (!address) {
+      throw new Error(
+        `MetaDogModule address not found in ${deployedAddressesPath}`
+      );
+    }
   } catch (err) {
-    console.error('Error:', err);
+    console.error('Error reading deployed addresses:', err);
+    throw err;
+  }
+
+  console.log(`MetaDog contract address: ${address}`);
+
+  // Prepare the parameters
+  const parameters = {
+    MetaDogReveal: {
+      address,
+      revealTokenURI,
+    },
+  };
+
+  // Define the parameter file path
+  const dirPath = path.resolve(__dirname, '../ignition/parameters');
+  const filePath = path.resolve(dirPath, 'metaDogReveal.json');
+
+  // Ensure the parameters directory exists
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+    console.log(`Directory created: ${dirPath}`);
+  }
+
+  // Write the parameters to the file
+  writeFileSync(filePath, JSON.stringify(parameters, null, 2));
+  console.log(`Parameters written to ${filePath}:`);
+  console.log(JSON.stringify(parameters, null, 2));
+
+  // Construct the deployment command
+  const modulePath = path.resolve(
+    __dirname,
+    '../ignition/modules/metaDogReveal.ts'
+  );
+  const command = `npx hardhat ignition deploy ${modulePath} --parameters ${filePath} --network btp`;
+
+  console.log(`Executing deployment: ${command}`);
+
+  // Execute the deployment command
+  try {
+    execSync(command, { stdio: 'inherit' });
+    console.log('MetaDogReveal deployed successfully.');
+  } catch (err) {
+    console.error('Error during deployment:', err);
+    throw err;
   }
 }
 

--- a/tasks/ipfs-upload-file.ts
+++ b/tasks/ipfs-upload-file.ts
@@ -39,7 +39,7 @@ async function ipfsUpload(
 
   const btpIpfs = process.env.BTP_IPFS;
 
-  if (btpIpfs?.includes('api.thegraph.com') || !btpIpfs) {
+  if (btpIpfs?.includes('network.thegraph.com') || !btpIpfs) {
     throw new Error(`No IPFS node found or configured wrong.`);
   }
   const lastSlashIndex = btpIpfs.lastIndexOf('/');


### PR DESCRIPTION
Running an ignition module from a script does not work on private networks when hardhat-toolbox-viem is used.
I changed the scripts to execute an npx command instead.

## Summary by Sourcery

Bug Fixes:
- Fix script execution on private networks by replacing direct module deployment with npx command execution.